### PR TITLE
[codex] docs: add missing CVE-2020-8554 patch pages

### DIFF
--- a/content/en/docs/kubernetes/patches/cve-2020-8554.md
+++ b/content/en/docs/kubernetes/patches/cve-2020-8554.md
@@ -1,0 +1,26 @@
+---
+title: CVE-2020-8554
+weight: -20200008554
+short_description: |
+  A man-in-the-middle risk in Kubernetes `Service` traffic handling allows an actor with `Service` write permissions to redirect traffic using `ExternalIPs` or `LoadBalancer` status fields.
+---
+
+{{< link text="Vulnerability details" url="https://www.cvedetails.com/cve/CVE-2020-8554" >}}
+{{< link text="Upstream issue" url="https://github.com/kubernetes/kubernetes/issues/97076" >}}
+
+CVE-2020-8554 describes a traffic interception risk in Kubernetes service handling. An actor with permissions to create or update `Service` resources can abuse `spec.externalIPs` or `status.loadBalancer.ingress.ip` to redirect traffic.
+
+## Scope {#scope}
+
+Clusters that allow untrusted tenants to create or update `Service` objects are affected.
+
+## Prevention {#prevention}
+
+- Restrict who can create or update `Service` resources.
+- Restrict or deny untrusted `ExternalIPs` usage through admission policy.
+- Audit and monitor changes to `Service` status updates, especially `LoadBalancer` ingress IP updates.
+
+## Fixed by KLTS {#klts-fixed}
+
+- {{< link url="/docs/kubernetes/releases/v1.19/v1.19.16-lts.3/" >}} {{< link text="CVE-2020-8554.1.19.patch" url="https://github.com/klts-io/kubernetes-lts/raw/main/patches/CVE-2020-8554.1.19.patch" >}}
+- {{< link url="/docs/kubernetes/releases/v1.18/v1.18.20-lts.3/" >}} {{< link text="CVE-2020-8554.1.18.patch" url="https://github.com/klts-io/kubernetes-lts/raw/main/patches/CVE-2020-8554.1.18.patch" >}}

--- a/content/zh/docs/kubernetes/patches/cve-2020-8554.md
+++ b/content/zh/docs/kubernetes/patches/cve-2020-8554.md
@@ -1,0 +1,26 @@
+---
+title: CVE-2020-8554
+weight: -20200008554
+short_description: |
+  Kubernetes `Service` 流量处理存在中间人风险，具备 `Service` 写权限的用户可通过 `ExternalIPs` 或 `LoadBalancer` 状态字段重定向流量。
+---
+
+{{< link text="漏洞详情" url="https://www.cvedetails.com/cve/CVE-2020-8554" >}}
+{{< link text="上游问题" url="https://github.com/kubernetes/kubernetes/issues/97076" >}}
+
+CVE-2020-8554 描述的是 Kubernetes 服务流量被拦截的风险。具有创建或更新 `Service` 资源权限的用户，可能通过滥用 `spec.externalIPs` 或 `status.loadBalancer.ingress.ip` 重定向流量。
+
+## 漏洞影响 {#scope}
+
+允许不可信租户创建或更新 `Service` 对象的集群会受到影响。
+
+## 防范措施 {#prevention}
+
+- 限制可创建或更新 `Service` 资源的用户范围。
+- 通过准入策略限制或拒绝不可信的 `ExternalIPs` 使用。
+- 审计并监控 `Service` 状态更新，尤其是 `LoadBalancer` ingress IP 的更新。
+
+## KLTS 修复的版本 {#klts-fixed}
+
+- {{< link url="/docs/kubernetes/releases/v1.19/v1.19.16-lts.3/" >}} {{< link text="CVE-2020-8554.1.19.patch" url="https://github.com/klts-io/kubernetes-lts/raw/main/patches/CVE-2020-8554.1.19.patch" >}}
+- {{< link url="/docs/kubernetes/releases/v1.18/v1.18.20-lts.3/" >}} {{< link text="CVE-2020-8554.1.18.patch" url="https://github.com/klts-io/kubernetes-lts/raw/main/patches/CVE-2020-8554.1.18.patch" >}}


### PR DESCRIPTION
## Summary
- add missing English CVE patch page: content/en/docs/kubernetes/patches/cve-2020-8554.md
- add missing Chinese CVE patch page: content/zh/docs/kubernetes/patches/cve-2020-8554.md
- include links to existing KLTS patch artifacts for v1.19 and v1.18 releases

## Why
Issue #42 tracks missing documentation for CVE-2020-8554, and release pages already reference this page path.

## Validation
- checked both new markdown files match existing CVE page structure
- verified only two files are included in this PR

Fixes #42