### PR TITLE
docs: add containerd and Kubernetes compatibility section

### DIFF
--- a/content/en/docs/containerd/_index.md
+++ b/content/en/docs/containerd/_index.md
@@ -3,4 +3,19 @@ title: Containerd
 weight: 200
 ---
 
-<!--add blocks of content here to add more sections to the community page -->
+## Kubernetes and Containerd Compatibility
+
+The table below summarizes the latest Kubernetes-to-containerd recommendations
+from the upstream containerd release policy.
+
+| Kubernetes Version | Recommended containerd Version         | CRI Version |
+| --- | --- | --- |
+| 1.32 | 2.1.0+, 2.0.1+, 1.7.24+, 1.6.36+ | v1 |
+| 1.33 | 2.1.0+, 2.0.4+, 1.7.24+, 1.6.36+ | v1 |
+| 1.34 | 2.1.3+, 2.0.6+, 1.7.28+, 1.6.39+ | v1 |
+| 1.35 | 2.2.0+, 2.1.5+, 1.7.28+ | v1 |
+
+## References
+
+- {{< link text="KLTS containerd-lts maintenance status" url="https://github.com/klts-io/containerd-lts/blob/main/README.md" >}}
+- {{< link text="containerd upstream release and compatibility policy" url="https://github.com/containerd/containerd/blob/main/RELEASES.md" >}}

--- a/content/zh/docs/containerd/_index.md
+++ b/content/zh/docs/containerd/_index.md
@@ -3,4 +3,19 @@ title: Containerd
 weight: 200
 ---
 
-<!--add blocks of content here to add more sections to the community page -->
+## Kubernetes 与 Containerd 兼容性
+
+下表整理了 containerd 社区最新发布策略中给出的 Kubernetes 与
+containerd 推荐组合。
+
+| Kubernetes 版本 | 推荐的 containerd 版本 | CRI 版本 |
+| --- | --- | --- |
+| 1.32 | 2.1.0+, 2.0.1+, 1.7.24+, 1.6.36+ | v1 |
+| 1.33 | 2.1.0+, 2.0.4+, 1.7.24+, 1.6.36+ | v1 |
+| 1.34 | 2.1.3+, 2.0.6+, 1.7.28+, 1.6.39+ | v1 |
+| 1.35 | 2.2.0+, 2.1.5+, 1.7.28+ | v1 |
+
+## 参考资料
+
+- {{< link text="KLTS containerd-lts 维护状态" url="https://github.com/klts-io/containerd-lts/blob/main/README.md" >}}
+- {{< link text="containerd 社区发布与兼容性策略" url="https://github.com/containerd/containerd/blob/main/RELEASES.md" >}}


### PR DESCRIPTION
Fixes #20

## Summary
- add a Kubernetes/containerd compatibility section to containerd docs in English and Chinese
- include latest upstream compatibility matrix from containerd RELEASES.md
- add source links to:
  - klts-io/containerd-lts README
  - containerd/containerd RELEASES.md

## Updated files
- content/en/docs/containerd/_index.md
- content/zh/docs/containerd/_index.md
